### PR TITLE
Fixed mutable begin() for basic_mmap.

### DIFF
--- a/include/mio/mmap.hpp
+++ b/include/mio/mmap.hpp
@@ -151,7 +151,10 @@ public:
      * Returns an iterator to the first requested byte, if a valid memory mapping
      * exists, otherwise this function call is equivalent to invoking `end`.
      */
-    iterator begin() noexcept { return impl_.begin(); }
+    template<
+        access_mode A = AccessMode,
+        typename = typename std::enable_if<A == access_mode::write>::type
+    > iterator begin() noexcept { return impl_.begin(); }
     const_iterator begin() const noexcept { return impl_.begin(); }
     const_iterator cbegin() const noexcept { return impl_.cbegin(); }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8963710/38765029-02f71fbc-3f88-11e8-9d91-feae2017a7ad.png)

I got that warning when using a range-based for loop using `const auto`. Both  `begin()` and `end()` need to return the same iterator type, but there was some missing template code that caused a mixup.