### PR TITLE
Add CMakeLists.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 test/**
 !test/test.cpp
 !test/example.cpp
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required( VERSION 3.2.2 )
+project( mio )
+
+### Standard
+set( CMAKE_CXX_STANDARD 11 )
+set( CMAKE_CXX_STANDARD_REQUIRED ON )
+set( CMAKE_CXX_EXTENSIONS ON )
+
+### Verbosity
+set( CMAKE_COLOR_MAKEFILE ON )
+set( CMAKE_VERBOSE_MAKEFILE ON )
+
+# Generate 'compile_commands.json' for clang_complete
+set( CMAKE_EXPORT_COMPILE_COMMANDS ON )
+
+### Flags
+if( MSVC )
+	add_compile_options( /W3 )
+elseif( CMAKE_COMPILER_IS_GNUCXX )
+	add_compile_options( -Wall )
+	add_compile_options( -Wextra )
+endif()
+
+### Library targets
+add_library( mio INTERFACE)
+target_include_directories( mio INTERFACE include )
+
+### Test targets
+
+## test
+add_executable(
+	test
+	test/test.cpp
+)
+target_link_libraries( test PRIVATE mio )
+
+## example
+add_executable(
+	example
+	test/example.cpp
+)
+target_link_libraries( example PRIVATE mio )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,40 +3,34 @@ project( mio )
 
 ### Standard
 set( CMAKE_CXX_STANDARD 11 )
-set( CMAKE_CXX_STANDARD_REQUIRED ON )
-set( CMAKE_CXX_EXTENSIONS ON )
-
-### Verbosity
-set( CMAKE_COLOR_MAKEFILE ON )
-set( CMAKE_VERBOSE_MAKEFILE ON )
 
 # Generate 'compile_commands.json' for clang_complete
 set( CMAKE_EXPORT_COMPILE_COMMANDS ON )
 
-### Flags
-if( MSVC )
-	add_compile_options( /W3 )
-elseif( CMAKE_COMPILER_IS_GNUCXX )
-	add_compile_options( -Wall )
-	add_compile_options( -Wextra )
-endif()
+### Flags/Options
+option( BUILD_TESTS "Enable the building of mio unit tests" OFF )
 
 ### Library targets
 add_library( mio INTERFACE)
 target_include_directories( mio INTERFACE include )
+install(
+	DIRECTORY include/
+	DESTINATION include
+)
 
 ### Test targets
-
-## test
-add_executable(
-	test
-	test/test.cpp
-)
-target_link_libraries( test PRIVATE mio )
-
-## example
-add_executable(
-	example
-	test/example.cpp
-)
-target_link_libraries( example PRIVATE mio )
+if( BUILD_TESTS )
+	## test
+	add_executable(
+		test
+		test/test.cpp
+	)
+	target_link_libraries( test PRIVATE mio )
+	
+	## example
+	add_executable(
+		example
+		test/example.cpp
+	)
+	target_link_libraries( example PRIVATE mio )
+endif()

--- a/README.md
+++ b/README.md
@@ -140,3 +140,17 @@ Though generally not needed, since mio maps users requested offsets to page boun
 
 ### Installation
 mio is a header-only library, so just copy the contents in `mio/include` into your system wide include path, such as `/usr/include`, or into your project's lib folder.
+
+## CMake
+A `CMakeLists.txt` is provided to allow easy git submodule usage or installation.
+
+To use as a submodule, clone mio within your project's dependencies/externals folder and add:
+```
+add_subdirectory( dependencies_folder/mio )
+target_link_libraries( MyCoolProject mio )
+```
+to your project's `CMakeLists.txt` to add mio into `MyCoolProject`'s include-space.
+
+To install, do an out-of-source build(such as making a `build` folder and running `cmake ..` inside of it) and then run `sudo make install` to copy relevant include files to 
+
+The optional `BUILD_TESTS` option can be used to build unit tests(off by default) by instead using `cmake -DBUILD_TESTS=ON ..`

--- a/test/example.cpp
+++ b/test/example.cpp
@@ -1,4 +1,4 @@
-#include "../include/mio/mmap.hpp"
+#include <mio/mmap.hpp>
 #include <system_error> // for std::error_code
 #include <cstdio> // for std::printf
 #include <cassert>

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,5 +1,5 @@
-#include "../include/mio/mmap.hpp"
-#include "../include/mio/shared_mmap.hpp"
+#include <mio/mmap.hpp>
+#include <mio/shared_mmap.hpp>
 
 #include <string>
 #include <fstream>


### PR DESCRIPTION
Added a CMakeLists.txt for convenience of git/CMake submodule usage, and to make installation of the library(and building of unit tests) a little easier:
```
% cmake ..
-- Configuring done
-- Generating done
-- Build files have been written to: /blah/blah/blah/build
% sudo make install
Install the project...
-- Install configuration: ""
-- Up-to-date: /usr/local/include
-- Installing: /usr/local/include/mio
-- Installing: /usr/local/include/mio/page.hpp
-- Installing: /usr/local/include/mio/detail
-- Installing: /usr/local/include/mio/detail/string_util.hpp
-- Installing: /usr/local/include/mio/detail/basic_mmap.hpp
-- Installing: /usr/local/include/mio/detail/basic_mmap.ipp
-- Installing: /usr/local/include/mio/shared_mmap.hpp
-- Installing: /usr/local/include/mio/mmap.hpp
```

also added a `BUILD_TESTS` option in cmake to build the unit tests(off by default).