### PR TITLE
Windows unicode compilation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ int main()
 ```
 However, mio does not check whether the provided file descriptor has the same access permissions as the desired mapping, so the mapping may fail. Such errors are reported via the `std::error_code` out parameter that is passed to the mapping function.
 
+**WINDOWS USERS**: This library doesn't support the use of wide character 
+types for functions where character strings are expected (e.g. path parameters).
+
 ### Example
 
 ```c++
@@ -249,6 +252,7 @@ cmake --build . --config Release --target install
 ```
 
 Note that the last command of the installation sequence may require administrator privileges (e.g. `sudo`) if the installation root directory lies outside your home directory.
+
 This installation
 + copies the mio header files to the `include/mio` subdirectory of the installation root
 + generates and copies several CMake configuration files to the `share/cmake/mio` subdirectory of the installation root

--- a/include/mio/detail/basic_mmap.ipp
+++ b/include/mio/detail/basic_mmap.ipp
@@ -72,7 +72,7 @@ file_handle_type open_file(const String& path,
         return INVALID_HANDLE_VALUE;
     }
 #ifdef _WIN32
-    const auto handle = ::CreateFile(c_str(path),
+    const auto handle = ::CreateFileA(c_str(path),
         mode == access_mode::read ? GENERIC_READ : GENERIC_READ | GENERIC_WRITE,
         FILE_SHARE_READ | FILE_SHARE_WRITE,
         0,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,11 +5,6 @@ add_test(NAME mio.test COMMAND mio.test)
 if(WIN32)
     add_executable(mio.unicode.test unicode_test.cpp)
     target_link_libraries(mio.unicode.test PRIVATE mio::mio)
-    target_compile_options(
-        mio.unicode.test 
-        PRIVATE 
-        $<$<CXX_COMPILER_ID:MSVC>:/Zc:wchar_t>
-    )
     target_compile_definitions(mio.unicode.test PRIVATE UNICODE)
     add_test(NAME mio.unicode.test COMMAND mio.test)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,14 @@ add_executable(mio.test test.cpp)
 target_link_libraries(mio.test PRIVATE mio::mio)
 add_test(NAME mio.test COMMAND mio.test)
 
-add_executable(mio.example example.cpp)
-target_link_libraries(mio.example PRIVATE mio::mio)
-add_test(NAME mio.example COMMAND mio.example)
+if(WIN32)
+    add_executable(mio.unicode.test unicode_test.cpp)
+    target_link_libraries(mio.unicode.test PRIVATE mio::mio)
+    target_compile_options(
+        mio.unicode.test 
+        PRIVATE 
+        $<$<CXX_COMPILER_ID:MSVC>:/Zc:wchar_t>
+    )
+    target_compile_definitions(mio.unicode.test PRIVATE UNICODE)
+    add_test(NAME mio.unicode.test COMMAND mio.test)
+endif()


### PR DESCRIPTION
`CreateFile` is `#define`d as `CreateFileW` in unicode builds (when `/D UNICODE` is defined). This is probably more likely to be a issue when integrating into GUI projects.

This commit allows compilation to succeed when `UNICODE` has been defined and adds a note to the README, explicitly stating that mio doesn't support wide char string types as parameters.

I've also added a test in the CMake configuration (only for `WIN32`) that just compiles the tests again, but with the `/D UNICODE` macro defined.