### PR TITLE
Fixes missing test file

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,7 +3,7 @@ target_link_libraries(mio.test PRIVATE mio::mio)
 add_test(NAME mio.test COMMAND mio.test)
 
 if(WIN32)
-    add_executable(mio.unicode.test unicode_test.cpp)
+    add_executable(mio.unicode.test test.cpp)
     target_link_libraries(mio.unicode.test PRIVATE mio::mio)
     target_compile_definitions(mio.unicode.test PRIVATE UNICODE)
     add_test(NAME mio.unicode.test COMMAND mio.test)


### PR DESCRIPTION
For an earlier PR (#16), I introduced a new test file for testing unicode support on Windows. The project's `.gitignore` file excludes the entire test directory, so it was missed out. My apologies. Turns out that this test file wasn't actually needed, but the CMake config still uses it. This commit just changes this back to the original `test.cpp` file.