### PR TITLE
Fix shared_mmap constructor method

### DIFF
--- a/include/mio/shared_mmap.hpp
+++ b/include/mio/shared_mmap.hpp
@@ -326,7 +326,7 @@ private:
         }
         else
         {
-            pimpl_->map(token, offset, length, AccessMode, error);
+            pimpl_->map(token, offset, length, error);
         }
     }
 };


### PR DESCRIPTION
Seems like code 
`mio::shared_mmap_source mmap("file.txt", 0, mio::map_entire_file);` 
can not compile..