### PR TITLE
Throw std::system_error

### DIFF
--- a/include/mio/mmap.hpp
+++ b/include/mio/mmap.hpp
@@ -112,7 +112,7 @@ public:
     {
         std::error_code error;
         map(path, offset, length, error);
-        if(error) { throw error; }
+        if(error) { throw std::system_error(error); }
     }
 
     /**
@@ -123,7 +123,7 @@ public:
     {
         std::error_code error;
         map(handle, offset, length, error);
-        if(error) { throw error; }
+        if(error) { throw std::system_error(error); }
     }
 
     /**

--- a/include/mio/shared_mmap.hpp
+++ b/include/mio/shared_mmap.hpp
@@ -96,7 +96,7 @@ public:
     {
         std::error_code error;
         map(path, offset, length, error);
-        if(error) { throw error; }
+        if(error) { throw std::system_error(error); }
     }
 
     /**
@@ -107,7 +107,7 @@ public:
     {
         std::error_code error;
         map(handle, offset, length, error);
-        if(error) { throw error; }
+        if(error) { throw std::system_error(error); }
     }
 
     /**


### PR DESCRIPTION
Issue #26 

Throwing system_error rather than error_code

**Note: This is a breaking change**