### PR TITLE
Conditionally enable the exception-throwing constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ or:
 ```c++
 mmap.map(path, error);
 ```
+**NOTE:** The constructors **require** exceptions to be enabled. If you prefer
+to build your projects with `-fno-exceptions`, you can still use the other ways.
 
 Moreover, in each case, you can provide either some string type for the file's path, or you can use an existing, valid file handle.
 ```c++

--- a/include/mio/mmap.hpp
+++ b/include/mio/mmap.hpp
@@ -128,7 +128,8 @@ public:
         map(handle, offset, length, error);
         if(error) { throw std::system_error(error); }
     }
-#endif
+#endif // __cpp_exceptions
+
     /**
      * `basic_mmap` has single-ownership semantics, so transferring ownership
      * may only be accomplished by moving the object.

--- a/include/mio/mmap.hpp
+++ b/include/mio/mmap.hpp
@@ -103,6 +103,7 @@ public:
      */
     basic_mmap() = default;
 
+#ifdef __cpp_exceptions
     /**
      * The same as invoking the `map` function, except any error that may occur
      * while establishing the mapping is wrapped in a `std::system_error` and is
@@ -127,7 +128,7 @@ public:
         map(handle, offset, length, error);
         if(error) { throw std::system_error(error); }
     }
-
+#endif
     /**
      * `basic_mmap` has single-ownership semantics, so transferring ownership
      * may only be accomplished by moving the object.

--- a/include/mio/shared_mmap.hpp
+++ b/include/mio/shared_mmap.hpp
@@ -112,7 +112,7 @@ public:
         map(handle, offset, length, error);
         if(error) { throw std::system_error(error); }
     }
-#endif
+#endif // __cpp_exceptions
 
     /**
      * If this is a read-write mapping and the last reference to the mapping,

--- a/include/mio/shared_mmap.hpp
+++ b/include/mio/shared_mmap.hpp
@@ -87,6 +87,7 @@ public:
         return *this;
     }
 
+#ifdef __cpp_exceptions
     /**
      * The same as invoking the `map` function, except any error that may occur
      * while establishing the mapping is wrapped in a `std::system_error` and is
@@ -111,6 +112,7 @@ public:
         map(handle, offset, length, error);
         if(error) { throw std::system_error(error); }
     }
+#endif
 
     /**
      * If this is a read-write mapping and the last reference to the mapping,


### PR DESCRIPTION
This allows MIO to be compiled with -fno-exceptions, as that is the only place where MIO uses them, and they are simply convenience wrappers.