### PR TITLE
Fixed typo in CMake config file.

### DIFF
--- a/cmake/mio-config.cmake.in
+++ b/cmake/mio-config.cmake.in
@@ -7,7 +7,7 @@ CMAKE_DEPENDENT_OPTION(mio.windows.full_api
 include("${CMAKE_CURRENT_LIST_DIR}/mio-targets.cmake")
 
 if(NOT mio.windows.full_api)
-  set_propery(TARGET mio::mio APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS
+  set_property(TARGET mio::mio APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS
     WIN32_LEAN_AND_MEAN
     NOMINMAX)
 endif()


### PR DESCRIPTION
Tried using mio on Windows 10, noticed a typo in the .cmake file.