### PR TITLE
Add inline specifier to s_2_ws() function

### DIFF
--- a/include/mio/detail/mmap.ipp
+++ b/include/mio/detail/mmap.ipp
@@ -52,7 +52,7 @@ inline DWORD int64_low(int64_t n) noexcept
     return n & 0xffffffff;
 }
 
-std::wstring s_2_ws(const std::string& s)
+inline std::wstring s_2_ws(const std::string& s)
 {
     if (s.empty())
         return{};

--- a/single_include/mio/mio.hpp
+++ b/single_include/mio/mio.hpp
@@ -794,7 +794,7 @@ inline DWORD int64_low(int64_t n) noexcept
     return n & 0xffffffff;
 }
 
-std::wstring s_2_ws(const std::string& s)
+inline std::wstring s_2_ws(const std::string& s)
 {
     if (s.empty())
         return{};


### PR DESCRIPTION
This fixes a linker error about duplicate symbols, if you include the mio headers from multiple source files.