### PR TITLE
include missing vector in detail/mmap.ipp

### DIFF
--- a/include/mio/detail/mmap.ipp
+++ b/include/mio/detail/mmap.ipp
@@ -27,7 +27,9 @@
 
 #include <algorithm>
 
-#ifndef _WIN32
+#ifdef _WIN32
+# include <vector>
+#else
 # include <unistd.h>
 # include <fcntl.h>
 # include <sys/mman.h>

--- a/single_include/mio/mio.hpp
+++ b/single_include/mio/mio.hpp
@@ -769,7 +769,9 @@ template<
 
 #include <algorithm>
 
-#ifndef _WIN32
+#ifdef _WIN32
+# include <vector>
+#else
 # include <unistd.h>
 # include <fcntl.h>
 # include <sys/mman.h>


### PR DESCRIPTION
I was using mio in a project compiled with mingw-w64 toolchain on arch and I noticed it was missing <vector>

```
In file included from /build/MIOProject/include/mio/mmap.hpp:490,
                 from /src/pack.cpp:6:
/build/MIOProject/include/mio/detail/mmap.ipp: In function ‘std::wstring mio::detail::win::s_2_ws(const string&)’:
/build/MIOProject/include/mio/detail/mmap.ipp:60:21: error: ‘vector’ is not a member of ‘std’
   60 |     auto buf = std::vector<wchar_t>(s_length);
      |                     ^~~~~~
/build/MIOProject/include/mio/detail/mmap.ipp:29:1: note: ‘std::vector’ is defined in header ‘<vector>’; did you forget to ‘#include <vector>’?
   28 | #include <algorithm>
  +++ |+#include <vector>
   29 | 
/build/MIOProject/include/mio/detail/mmap.ipp:60:28: error: expected primary-expression before ‘wchar_t’
   60 |     auto buf = std::vector<wchar_t>(s_length);
```

I also ran amalgamate.py for the single-include file, please correct me if I did it wrong.