### PR TITLE
Add missing `inline` to `s_2_ws()` to fix ODR violation

### DIFF
--- a/include/mio/detail/mmap.ipp
+++ b/include/mio/detail/mmap.ipp
@@ -52,7 +52,7 @@ inline DWORD int64_low(int64_t n) noexcept
     return n & 0xffffffff;
 }
 
-std::wstring s_2_ws(const std::string& s)
+inline std::wstring s_2_ws(const std::string& s)
 {
     if (s.empty())
         return{};

--- a/single_include/mio/mio.hpp
+++ b/single_include/mio/mio.hpp
@@ -794,7 +794,7 @@ inline DWORD int64_low(int64_t n) noexcept
     return n & 0xffffffff;
 }
 
-std::wstring s_2_ws(const std::string& s)
+inline std::wstring s_2_ws(const std::string& s)
 {
     if (s.empty())
         return{};


### PR DESCRIPTION
Hi! :wave:

On Windows, including `mmap.hpp` from multiple files fails to compile because of multiple definitions of `s_2_ws()`, this adds the missing `inline`. (I ran `amalgamate.py` but it made a bunch of unrelated changes, so I just manually made the change to the single-header file.)