### PR TITLE
Avoid multiply defined `s_2_ws` linker error

### DIFF
--- a/include/mio/detail/mmap.ipp
+++ b/include/mio/detail/mmap.ipp
@@ -52,14 +52,17 @@ inline DWORD int64_low(int64_t n) noexcept
     return n & 0xffffffff;
 }
 
-std::wstring s_2_ws(const std::string& s)
+inline std::wstring s_2_ws(const std::string& s)
 {
-    if (s.empty())
-        return{};
-    const auto s_length = static_cast<int>(s.length());
-    auto buf = std::vector<wchar_t>(s_length);
-    const auto wide_char_count = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), s_length, buf.data(), s_length);
-    return std::wstring(buf.data(), wide_char_count);
+    std::wstring ret;
+    if (!s.empty())
+    {
+        ret.resize(s.size());
+        int wide_char_count = MultiByteToWideChar(CP_UTF8, 0, s.c_str(),
+            static_cast<int>(s.size()), &ret[0], static_cast<int>(s.size()));
+        ret.resize(wide_char_count);
+    }
+    return ret;
 }
 
 template<

--- a/single_include/mio/mio.hpp
+++ b/single_include/mio/mio.hpp
@@ -794,14 +794,17 @@ inline DWORD int64_low(int64_t n) noexcept
     return n & 0xffffffff;
 }
 
-std::wstring s_2_ws(const std::string& s)
+inline std::wstring s_2_ws(const std::string& s)
 {
-    if (s.empty())
-        return{};
-    const auto s_length = static_cast<int>(s.length());
-    auto buf = std::vector<wchar_t>(s_length);
-    const auto wide_char_count = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), s_length, buf.data(), s_length);
-    return std::wstring(buf.data(), wide_char_count);
+    std::wstring ret;
+    if (!s.empty())
+    {
+        ret.resize(s.size());
+        int wide_char_count = MultiByteToWideChar(CP_UTF8, 0, s.c_str(),
+            static_cast<int>(s.size()), &ret[0], static_cast<int>(s.size()));
+        ret.resize(wide_char_count);
+    }
+    return ret;
 }
 
 template<


### PR DESCRIPTION
 + use std::wstring directly without intermediate std::vector in `s_2_ws`

fixes https://github.com/mandreyel/mio/issues/87