### PR TITLE
Default initialise is_handle_internal_

### DIFF
--- a/include/mio/mmap.hpp
+++ b/include/mio/mmap.hpp
@@ -97,7 +97,7 @@ private:
     // user provided it, but we must close it if we obtained it using the
     // provided path. For this reason, this flag is used to determine when to
     // close `file_handle_`.
-    bool is_handle_internal_;
+    bool is_handle_internal_{false};
 
 public:
     /**


### PR DESCRIPTION
gcc12 flags `is_handle_internal_` as maybe being uninitialised. This PR adds a default initialisation for `is_handle_internal_` to avoid this.
```
/usr/local/include/mio/detail/mmap.ipp:419:8: warning: '<anonymous>.mio::basic_mmap<mio::access_mode::write, char>::is_handle_internal_' may be used uninitialized [-Wmaybe-uninitialized]
  419 |     if(is_handle_internal_)
      |        ^~~~~~~~~~~~~~~~~~~
```