### PR TITLE
Undefining macro [max]

### DIFF
--- a/include/mio/mmap.hpp
+++ b/include/mio/mmap.hpp
@@ -490,3 +490,5 @@ mmap_sink make_mmap_sink(const MappingToken& token, std::error_code& error)
 #include "detail/mmap.ipp"
 
 #endif // MIO_MMAP_HEADER
+
+#undef max

--- a/single_include/mio/mio.hpp
+++ b/single_include/mio/mio.hpp
@@ -1758,3 +1758,5 @@ using shared_ummap_sink = basic_shared_mmap_sink<unsigned char>;
 } // namespace mio
 
 #endif // MIO_SHARED_MMAP_HEADER
+
+#undef max


### PR DESCRIPTION
Macro [max] is included and makes it impossible to use [std::max] unless it's undefined again.