### PR TITLE
Improve support for 32-bit builds on Windows

### DIFF
--- a/include/mio/mmap.hpp
+++ b/include/mio/mmap.hpp
@@ -57,7 +57,7 @@ template<access_mode AccessMode, typename ByteT>
 struct basic_mmap
 {
     using value_type = ByteT;
-    using size_type = size_t;
+    using size_type = int64_t;
     using reference = value_type&;
     using const_reference = const value_type&;
     using pointer = value_type*;

--- a/include/mio/page.hpp
+++ b/include/mio/page.hpp
@@ -66,7 +66,7 @@ inline size_t page_size()
  * difference until the nearest page boundary before `offset`, or does nothing if
  * `offset` is already page aligned.
  */
-inline size_t make_offset_page_aligned(size_t offset) noexcept
+inline int64_t make_offset_page_aligned(int64_t offset) noexcept
 {
     const size_t page_size_ = page_size();
     // Use integer division to round down to the nearest page alignment.


### PR DESCRIPTION
This change allows mapping large files with offsets exceeding 32-bit boundary